### PR TITLE
Support for 32 bit compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 node-kcp-x
 ======================================
 
+This fork fixes compilation on win-32bit using a more recent version of "node-addon-api" dependency.
+Also tested in Electron v22.
+
 [![Build Status][1]][2]
 
 [1]: https://api.travis-ci.org/leenjewel/node-kcp.svg?branch=master

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.2",
   "description": "KCP protocol for Node.js",
   "dependencies": {
-    "node-addon-api": "^5.0.0"
+    "node-addon-api": "^6.0.0"
   },
   "devDependencies": {
     "bindings": "^1.5.0",


### PR DESCRIPTION
Updating the "node-addon-api" dependency resolves compilation issues on 32-bit windows.